### PR TITLE
#-87-plit-resultlist-depending-on-resourcetype

### DIFF
--- a/components/search/DiscoverySearchResults.vue
+++ b/components/search/DiscoverySearchResults.vue
@@ -81,6 +81,12 @@ export default {
       }
       return false
     },
+    isBeaconCatalogsResponse (resourceInfo) {
+      if (resourceInfo) {
+        return resourceInfo.queryType.includes('BEACON_CATALOG')
+      }
+      return false
+    },
     resourceHasResponseToBeListed (result) {
       return !result || !result.content || !result.content.response || !result.content.response.resultSets[0].results;
     }
@@ -96,15 +102,24 @@ export default {
     />
     <v-row no-gutters justify="center">
       <v-col cols="12">
+
+        <div>
+          <h4 v-if="!(searchResults.every(result => !result?.content.responseSummary.numTotalResults )) ">
+            Resource Level Results
+          </h4>
+        </div>
+
         <v-expansion-panels v-if="searchResults.length > 0 && !loading" class="mb-14">
           <v-progress-linear
             v-if="fetchedResources !== 0 && fetchedResources !== resources.length"
             indeterminate
             color="blue"
           ></v-progress-linear>
+
           <v-expansion-panel
             v-for="(result,i) in searchResults"
             :key="i"
+            v-if="!loggedIn && isBeaconCatalogsResponse(result.resourceInfo)"
           >
             <v-expansion-panel-header
               v-if="result && result.resourceName &&
@@ -119,23 +134,6 @@ export default {
                         @click="handleResourceInfoDialogIconClicked(result.resourceInfo)">
                   mdi-information-variant
                 </v-icon>
-                <v-tooltip
-                  v-if="!loggedIn && isBeaconIndividualsResponse(result.resourceInfo)"
-                  bottom
-                >
-                  <template v-slot:activator="{ on, attrs }">
-                    <v-icon
-                      v-bind="attrs"
-                      v-on="on"
-                      class="mr-1"
-                    >
-                      mdi-lock
-                    </v-icon>
-                  </template>
-                  <span>
-                    Please log in to access the filtering feature for this resource.
-                  </span>
-                </v-tooltip>
                 {{ result.resourceName }}
               </div>
               <div class="eph-results">
@@ -151,6 +149,65 @@ export default {
                 :resultContent="result.content.response.resultSets[0].results"
               />
             </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+
+        <div>
+          <h4 v-if="!(searchResults.every(result => !result?.content.responseSummary.numTotalResults ))">Record Level Results</h4>
+        </div>
+
+        <v-expansion-panels
+          v-if="searchResults.length > 0 && !loading"
+          class="mb-14"
+        >
+          <v-progress-linear
+            v-if="fetchedResources !== 0 && fetchedResources !== resources.length"
+            indeterminate
+            color="blue"
+          ></v-progress-linear>
+
+          <v-expansion-panel
+            v-for="(result,i) in searchResults"
+            :key="i"
+            v-if="isBeaconIndividualsResponse(result.resourceInfo)"
+          >
+            <v-expansion-panel-header
+              v-if="result && result.resourceName &&
+              result.content && result.content.responseSummary &&
+              result.content.responseSummary.numTotalResults"
+              :disabled="resourceHasResponseToBeListed(result)"
+              :hide-actions="resourceHasResponseToBeListed(result)"
+              class="expansion-header" tile color="rgb(68, 160, 252)"
+            >
+              <div class="eph-title">
+                <v-icon class="mr-1" @click.native.stop
+                        @click="handleResourceInfoDialogIconClicked(result.resourceInfo)">
+                  mdi-information-variant
+                </v-icon>
+
+                {{ result.resourceName }}
+              </div>
+              <div class="eph-results">
+                {{ result.content.responseSummary.numTotalResults }} result(s)
+              </div>
+              <v-tooltip
+                v-if="!loggedIn"
+                bottom
+              >
+                <template v-slot:activator="{ on, attrs }">
+                  <v-icon
+                    v-bind="attrs"
+                    v-on="on"
+                    class="mr-1"
+                  >
+                    mdi-lock
+                  </v-icon>
+                </template>
+                <span>
+                    Contact the Resource to access more information
+                  </span>
+              </v-tooltip>
+            </v-expansion-panel-header>
           </v-expansion-panel>
         </v-expansion-panels>
       </v-col>

--- a/components/search/SearchResultContent.vue
+++ b/components/search/SearchResultContent.vue
@@ -6,6 +6,7 @@ export default {
   data () {
     return {
       headers: [
+        { text: 'Type', value: 'type' },
         {
           text: 'Resource Name',
           align: 'start',
@@ -33,6 +34,7 @@ export default {
 </script>
 
 <template>
+
   <v-data-table
     class="mx-0 px-0"
     :headers="headers"
@@ -41,8 +43,8 @@ export default {
     item-key="name"
     disable-sort
   >
-    <template v-slot:item.name="{ item }">
-      <v-card :href="item.homepage" target="_blank"  outlined color="transparent" style="width: 200px;" class="py-1">
+    <template v-slot:item.type="{ item }">
+      <v-card :href="item.homepage" target="_blank"  outlined color="transparent">
         <div class="text-center d-inline align-center justify-space-around">
           <v-tooltip v-if="item.type === 'PatientRegistryDataset'" bottom>
             <template v-slot:activator="{ on, attrs }">
@@ -56,7 +58,7 @@ export default {
                 mdi-clipboard-text-search-outline
               </v-icon>
             </template>
-            <span>This resource is a patient registry.</span>
+            <span>This resource is a patient information registry.</span>
           </v-tooltip>
           <v-tooltip v-if="item.type === 'cell line'" bottom>
             <template v-slot:activator="{ on, attrs }">
@@ -72,6 +74,32 @@ export default {
             </template>
             <span>This resource is a cell line.</span>
           </v-tooltip>
+          <v-tooltip v-if="item.type === 'Dataset'" bottom>
+            <template v-slot:activator="{ on, attrs }">
+              <v-icon
+                :color="'orange'"
+                large
+                v-bind="attrs"
+                v-on="on"
+              >
+                mdi-database-search-outline
+              </v-icon>
+            </template>
+            <span>This source hold knowledge on rare diseases.</span>
+          </v-tooltip>
+          <v-tooltip v-if="item.type === 'Guideline'" bottom>
+            <template v-slot:activator="{ on, attrs }">
+              <v-icon
+                :color="'yellow'"
+                large
+                v-bind="attrs"
+                v-on="on"
+              >
+                mdi-book-check-outline
+              </v-icon>
+            </template>
+            <span>This source contains recommendations or instructions.</span>
+          </v-tooltip>
           <v-tooltip v-if="item.type === 'BiobankDataset'" bottom>
             <template v-slot:activator="{ on, attrs }">
               <v-icon
@@ -84,14 +112,18 @@ export default {
                 mdi-test-tube
               </v-icon>
             </template>
-            <span>The resource is a biobank.</span>
+            <span>The resource is a biobank and contains biological samples.</span>
           </v-tooltip>
-          {{ item.name }}
         </div>
       </v-card>
     </template>
+    <template v-slot:item.name="{ item }">
+      <v-card :href="item.homepage" target="_blank"  outlined color="transparent" style="width: 200px;" class="py-1">
+        {{ item.name }}
+      </v-card>
+    </template>
     <template v-slot:item.description="{ item }">
-      <v-card :href="item.homepage" target="_blank" outlined color="transparent">
+      <v-card :href="item.homepage" target="_blank" outlined color="transparent" >
         {{ item.description ? item.description : '-' }}
       </v-card>
     </template>
@@ -102,9 +134,3 @@ export default {
     </template>
   </v-data-table>
 </template>
-
-<style scoped>
-.v-card--link:before {
-  background: none;
-}
-</style>


### PR DESCRIPTION
Split in Recource-level Results and Record-level Results

**What's in the PR**

* Changes so that the results should be split into resource level results and record level results.

**How to test manually**

* Search results should be divided into resource-level results and record-level results.
