### PR TITLE
113-Show-resources-where-the-Filters-are-ignored

### DIFF
--- a/components/search/DiscoverySearchResults.vue
+++ b/components/search/DiscoverySearchResults.vue
@@ -138,6 +138,11 @@ export default {
               <div class="eph-results">
                 {{ result.content.responseSummary.numTotalResults }} result(s)
               </div>
+              <div>
+                <div v-for="(filters, warningKey) in result.content?.info?.warnings" :key="warningKey">
+                  <div v-for="(filter, index) in filters" :key="index">Ignored filters: {{ filter }}</div>
+                </div>
+              </div>
             </v-expansion-panel-header>
             <v-expansion-panel-content
               v-if="result && result.content &&
@@ -191,6 +196,11 @@ export default {
               <div class="eph-results">
                 {{ result.content.responseSummary.numTotalResults }} result(s)
               </div>
+              <div>
+                <div v-for="(filters, warningKey) in result.content?.info?.warnings" :key="warningKey">
+                  <div v-for="(filter, index) in filters" :key="index">Ignored filters: {{ filter }}</div>
+                </div>
+              </div>
               <v-tooltip
                 v-if="!loggedIn"
                 bottom
@@ -219,6 +229,7 @@ export default {
         </p>
       </div>
     </v-row>
+    {{searchResults}}
   </v-container>
 
 </template>

--- a/components/search/DiscoverySearchResults.vue
+++ b/components/search/DiscoverySearchResults.vue
@@ -229,7 +229,6 @@ export default {
         </p>
       </div>
     </v-row>
-    {{searchResults}}
   </v-container>
 
 </template>


### PR DESCRIPTION
Adding the Ignored Filters information when displaying search results to resources where filters are ignored.

**What's in the PR**
* Adding the Ignored Filters information when displaying search results to resources where filters are ignored.

**How to test manually**
* Carry out a search.
* In the search results, Ignored Filters should be shown in case filters are ignored for the search.
